### PR TITLE
fix: parse limit/skip for MongoDB 3.2

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -35,8 +35,8 @@
      */
     find(req, res, next) {
 
-      var limit = req.query.limit || 25;
-      var skip = req.query.skip || 0;
+      var limit = parseInt(req.query.limit, 10) || 25;
+      var skip = parseInt(req.query.skip, 10) || 0;
       var criteria = req.query.criteria || req.query.criteria || req.query.selection || "{}";
 
       if (typeof criteria === "string") {


### PR DESCRIPTION
Closes #12